### PR TITLE
fix: .env.example to correctly forward the environment to expo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,1 @@
-ENVIRONMENT=development
+EXPO_PUBLIC_ENVIRONMENT=development


### PR DESCRIPTION
- add `EXPO_PUBLIC` prefix to environment variable